### PR TITLE
Add Tauri app with Prisma-backed activity workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/node_modules
+/dist
+/.turbo
+/.pnpm-store
+/src-tauri/target
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -1,103 +1,12 @@
-<!DOCTYPE html>
-<html lang="th" data-theme="light">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ระบบจัดการข้อมูล - หน้าหลัก</title>
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.7.2/dist/full.min.css" rel="stylesheet" type="text/css" />
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-</head>
-<body class="bg-gray-100">
-    <div id="menu-container"></div>
-
-    <div class="main-container">
-        <div class="chat-container">
-            <div class="chat-messages" id="chatMessages">
-                <div class="chat chat-start">
-                    <div class="chat-image avatar">
-                        <div class="w-10 rounded-full">
-                            <img src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp" />
-                        </div>
-                    </div>
-                    <div class="chat-header">
-                        ระบบ
-                        <time class="text-xs opacity-50">เริ่มต้น</time>
-                    </div>
-                    <div class="chat-bubble">ยินดีต้อนรับสู่หน้าหลัก!</div>
-                    <div class="chat-footer opacity-50">เริ่มใช้งาน</div>
-                </div>
-            </div>
-            <div class="chat-input">
-                <div class="flex gap-2">
-                    <input type="text" id="searchInput" class="flex-1 input input-bordered w-full" placeholder="พิมพ์คำสั่ง...">
-                    <button onclick="processCommand()" class="btn btn-primary">ส่ง</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <script src="script.js"></script>
-    <script>
-        checkLogin();
-
-        fetch('menu.html')
-            .then(response => {
-                if (!response.ok) throw new Error('Failed to load menu.html');
-                return response.text();
-            })
-            .then(data => {
-                document.getElementById('menu-container').innerHTML = data;
-                console.log('Menu loaded successfully');
-            })
-            .catch(error => console.error('Error loading menu:', error));
-
-        function addMessage(content, isUser = false) {
-            const messagesDiv = document.getElementById('chatMessages');
-            const messageDiv = document.createElement('div');
-            messageDiv.className = `chat ${isUser ? 'chat-end' : 'chat-start'}`;
-            
-            messageDiv.innerHTML = `
-                <div class="chat-image avatar">
-                    <div class="w-10 rounded-full">
-                        <img src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp" />
-                    </div>
-                </div>
-                <div class="chat-header">
-                    ${isUser ? 'คุณ' : 'ระบบ'}
-                    <time class="text-xs opacity-50">${new Date().toLocaleTimeString('th-TH', { hour: '2-digit', minute: '2-digit' })}</time>
-                </div>
-                <div class="chat-bubble ${isUser ? 'bg-primary text-white' : ''}">${content}</div>
-                <div class="chat-footer opacity-50">${isUser ? 'ส่งแล้ว' : 'ตอบกลับ'}</div>
-            `;
-            
-            messagesDiv.appendChild(messageDiv);
-            messagesDiv.scrollTop = messagesDiv.scrollHeight;
-        }
-
-        function processCommand() {
-            const input = document.getElementById('searchInput').value.trim().toLowerCase();
-            if (!input) return;
-
-            addMessage(input, true);
-
-            if (input === "ไปที่ข้อมูลนักเรียน") {
-                window.location.href = "students.html";
-            } else if (input === "ไปที่คลังเอกสาร") {
-                window.location.href = "documents.html";
-            } else {
-                addMessage("คำสั่งไม่ถูกต้อง กรุณาลองใหม่ หรือใช้เมนูด้านบน");
-            }
-
-            document.getElementById('searchInput').value = '';
-        }
-
-        document.getElementById('searchInput').addEventListener('keypress', function(e) {
-            if (e.key === 'Enter') {
-                processCommand();
-            }
-        });
-    </script>
-</body>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KRUchat Activity Tracker</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "kruchat-io",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build",
+    "prisma:generate": "pnpm --dir src-tauri prisma generate",
+    "prisma:migrate": "pnpm --dir src-tauri prisma migrate deploy",
+    "prisma:seed": "pnpm --dir src-tauri prisma db seed"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-popover": "^1.0.7",
+    "@tauri-apps/api": "^1.5.0",
+    "@tanstack/react-query": "^5.28.3",
+    "clsx": "^2.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.49.2",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^1.5.7",
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8"
+  }
+}

--- a/src-tauri/.env
+++ b/src-tauri/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./dev.db"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kruchat-io"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+tauri-build = { version = "1.5", features = [] }
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+parking_lot = "0.12"
+once_cell = "1.18"
+rusqlite = { version = "0.29", features = ["bundled", "chrono"] }
+tauri = { version = "1.5", features = ["api-all"] }
+bcrypt = "0.15"
+anyhow = "1.0"

--- a/src-tauri/package.json
+++ b/src-tauri/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "kruchat-io-backend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prisma": "prisma",
+    "prisma:migrate": "prisma migrate deploy",
+    "prisma:generate": "prisma generate",
+    "prisma:seed": "prisma db seed"
+  },
+  "devDependencies": {
+    "prisma": "^5.9.1",
+    "tsx": "^4.7.0"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.9.1",
+    "bcryptjs": "^2.4.3"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  }
+}

--- a/src-tauri/prisma/migrations/20240101000000_init/migration.sql
+++ b/src-tauri/prisma/migrations/20240101000000_init/migration.sql
@@ -1,0 +1,129 @@
+-- Create tables
+CREATE TABLE "Role" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE "User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "email" TEXT NOT NULL UNIQUE,
+    "passwordHash" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "roleId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("roleId") REFERENCES "Role" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "YearlyGoal" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" INTEGER NOT NULL,
+    "year" INTEGER NOT NULL,
+    "targetHours" REAL NOT NULL,
+    "notes" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "YearlyGoal_userId_year_unique" UNIQUE ("userId", "year"),
+    FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "Activity" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "activityType" TEXT NOT NULL,
+    "provider" TEXT,
+    "activityDate" DATETIME NOT NULL,
+    "hours" REAL NOT NULL,
+    "reflection" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "ownerId" INTEGER NOT NULL,
+    "reviewerId" INTEGER,
+    "goalId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    FOREIGN KEY ("reviewerId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    FOREIGN KEY ("goalId") REFERENCES "YearlyGoal" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "Tag" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE "ActivityTag" (
+    "activityId" INTEGER NOT NULL,
+    "tagId" INTEGER NOT NULL,
+    PRIMARY KEY ("activityId", "tagId"),
+    FOREIGN KEY ("activityId") REFERENCES "Activity" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY ("tagId") REFERENCES "Tag" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "ActivityStatusHistory" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "activityId" INTEGER NOT NULL,
+    "status" TEXT NOT NULL,
+    "comment" TEXT,
+    "changedById" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("activityId") REFERENCES "Activity" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY ("changedById") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "ActivityComment" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "activityId" INTEGER NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("activityId") REFERENCES "Activity" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "EvidenceMetadata" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "activityId" INTEGER NOT NULL UNIQUE,
+    "fileName" TEXT NOT NULL,
+    "filePath" TEXT NOT NULL,
+    "mimeType" TEXT,
+    "uploadedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("activityId") REFERENCES "Activity" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "RubricConfiguration" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "weight" REAL NOT NULL,
+    "active" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER update_User_updatedAt
+AFTER UPDATE ON "User"
+FOR EACH ROW
+BEGIN
+    UPDATE "User" SET "updatedAt" = CURRENT_TIMESTAMP WHERE "id" = NEW."id";
+END;
+
+CREATE TRIGGER update_RubricConfiguration_updatedAt
+AFTER UPDATE ON "RubricConfiguration"
+FOR EACH ROW
+BEGIN
+    UPDATE "RubricConfiguration" SET "updatedAt" = CURRENT_TIMESTAMP WHERE "id" = NEW."id";
+END;
+
+CREATE TRIGGER update_Activity_updatedAt
+AFTER UPDATE ON "Activity"
+FOR EACH ROW
+BEGIN
+    UPDATE "Activity" SET "updatedAt" = CURRENT_TIMESTAMP WHERE "id" = NEW."id";
+END;
+
+CREATE TRIGGER update_YearlyGoal_updatedAt
+AFTER UPDATE ON "YearlyGoal"
+FOR EACH ROW
+BEGIN
+    UPDATE "YearlyGoal" SET "updatedAt" = CURRENT_TIMESTAMP WHERE "id" = NEW."id";
+END;

--- a/src-tauri/prisma/schema.prisma
+++ b/src-tauri/prisma/schema.prisma
@@ -1,0 +1,143 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+enum RoleName {
+  TEACHER
+  SUPERVISOR
+  ADMIN
+}
+
+enum ActivityType {
+  SERVICE
+  PROFESSIONAL_DEVELOPMENT
+  COMMUNITY
+  OTHER
+}
+
+enum ActivityStatus {
+  DRAFT
+  SUBMITTED
+  APPROVED
+  REJECTED
+}
+
+model Role {
+  id    Int      @id @default(autoincrement())
+  name  RoleName @unique
+  users User[]
+}
+
+model User {
+  id            Int              @id @default(autoincrement())
+  email         String           @unique
+  passwordHash  String
+  displayName   String
+  roleId        Int
+  role          Role             @relation(fields: [roleId], references: [id])
+  activities    Activity[]       @relation("UserActivities")
+  reviews       Activity[]       @relation("ActivityReviewer")
+  comments      ActivityComment[]
+  statusEntries ActivityStatusHistory[]
+  goals         YearlyGoal[]
+  createdAt     DateTime         @default(now())
+  updatedAt     DateTime         @updatedAt
+}
+
+model Activity {
+  id             Int                     @id @default(autoincrement())
+  title          String
+  activityType   ActivityType
+  provider       String?
+  activityDate   DateTime
+  hours          Float
+  reflection     String?
+  status         ActivityStatus          @default(DRAFT)
+  ownerId        Int
+  owner          User                    @relation("UserActivities", fields: [ownerId], references: [id])
+  reviewerId     Int?
+  reviewer       User?                   @relation("ActivityReviewer", fields: [reviewerId], references: [id])
+  tags           ActivityTag[]
+  statusHistory  ActivityStatusHistory[]
+  comments       ActivityComment[]
+  evidence       EvidenceMetadata?
+  goalId         Int?
+  goal           YearlyGoal?             @relation(fields: [goalId], references: [id])
+  createdAt      DateTime                @default(now())
+  updatedAt      DateTime                @updatedAt
+}
+
+model ActivityTag {
+  activity   Activity @relation(fields: [activityId], references: [id])
+  activityId Int
+  tag        Tag      @relation(fields: [tagId], references: [id])
+  tagId      Int
+
+  @@id([activityId, tagId])
+}
+
+model Tag {
+  id        Int           @id @default(autoincrement())
+  name      String        @unique
+  activities ActivityTag[]
+}
+
+model ActivityStatusHistory {
+  id         Int            @id @default(autoincrement())
+  activity   Activity       @relation(fields: [activityId], references: [id])
+  activityId Int
+  status     ActivityStatus
+  comment    String?
+  changedBy  User?          @relation(fields: [changedById], references: [id])
+  changedById Int?
+  createdAt  DateTime       @default(now())
+}
+
+model ActivityComment {
+  id         Int       @id @default(autoincrement())
+  activity   Activity  @relation(fields: [activityId], references: [id])
+  activityId Int
+  author     User      @relation(fields: [authorId], references: [id])
+  authorId   Int
+  body       String
+  createdAt  DateTime  @default(now())
+}
+
+model YearlyGoal {
+  id         Int       @id @default(autoincrement())
+  user       User      @relation(fields: [userId], references: [id])
+  userId     Int
+  year       Int
+  targetHours Float
+  notes      String?
+  activities Activity[]
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+
+  @@unique([userId, year])
+}
+
+model EvidenceMetadata {
+  id          Int      @id @default(autoincrement())
+  activity    Activity @relation(fields: [activityId], references: [id])
+  activityId  Int      @unique
+  fileName    String
+  filePath    String
+  mimeType    String?
+  uploadedAt  DateTime @default(now())
+}
+
+model RubricConfiguration {
+  id          Int      @id @default(autoincrement())
+  name        String
+  description String?
+  weight      Float
+  active      Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/src-tauri/prisma/seed.ts
+++ b/src-tauri/prisma/seed.ts
@@ -1,0 +1,148 @@
+import { PrismaClient, RoleName, ActivityStatus, ActivityType } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const password = await bcrypt.hash('password123', 10);
+
+  const roles = await Promise.all([
+    prisma.role.upsert({
+      where: { name: RoleName.TEACHER },
+      update: {},
+      create: { name: RoleName.TEACHER },
+    }),
+    prisma.role.upsert({
+      where: { name: RoleName.SUPERVISOR },
+      update: {},
+      create: { name: RoleName.SUPERVISOR },
+    }),
+    prisma.role.upsert({
+      where: { name: RoleName.ADMIN },
+      update: {},
+      create: { name: RoleName.ADMIN },
+    }),
+  ]);
+
+  const [teacherRole, supervisorRole] = roles;
+
+  const teacher = await prisma.user.upsert({
+    where: { email: 'teacher@example.com' },
+    update: {},
+    create: {
+      email: 'teacher@example.com',
+      passwordHash: password,
+      displayName: 'Taylor Teacher',
+      role: { connect: { id: teacherRole.id } },
+    },
+  });
+
+  const supervisor = await prisma.user.upsert({
+    where: { email: 'supervisor@example.com' },
+    update: {},
+    create: {
+      email: 'supervisor@example.com',
+      passwordHash: password,
+      displayName: 'Sam Supervisor',
+      role: { connect: { id: supervisorRole.id } },
+    },
+  });
+
+  await prisma.rubricConfiguration.createMany({
+    skipDuplicates: true,
+    data: [
+      {
+        name: 'Impact',
+        description: 'How the activity impacts learners or community.',
+        weight: 0.4,
+      },
+      {
+        name: 'Reflection',
+        description: 'Quality of reflection submitted by the educator.',
+        weight: 0.3,
+      },
+      {
+        name: 'Evidence',
+        description: 'Strength of supporting evidence provided.',
+        weight: 0.3,
+      },
+    ],
+  });
+
+  const goal = await prisma.yearlyGoal.upsert({
+    where: {
+      userId_year: {
+        userId: teacher.id,
+        year: new Date().getFullYear(),
+      },
+    },
+    update: {},
+    create: {
+      userId: teacher.id,
+      year: new Date().getFullYear(),
+      targetHours: 40,
+      notes: 'Default target for professional development.',
+    },
+  });
+
+  await prisma.activity.upsert({
+    where: { id: 1 },
+    update: {},
+    create: {
+      title: 'STEM Workshop',
+      activityType: ActivityType.PROFESSIONAL_DEVELOPMENT,
+      provider: 'Local University',
+      activityDate: new Date(),
+      hours: 4,
+      reflection: 'Great opportunity to collaborate with peers.',
+      status: ActivityStatus.SUBMITTED,
+      ownerId: teacher.id,
+      reviewerId: supervisor.id,
+      goalId: goal.id,
+      tags: {
+        create: [
+          {
+            tag: {
+              connectOrCreate: {
+                where: { name: 'STEM' },
+                create: { name: 'STEM' },
+              },
+            },
+          },
+          {
+            tag: {
+              connectOrCreate: {
+                where: { name: 'Workshop' },
+                create: { name: 'Workshop' },
+              },
+            },
+          },
+        ],
+      },
+      statusHistory: {
+        create: [
+          {
+            status: ActivityStatus.DRAFT,
+            comment: 'Initial draft created.',
+            changedById: teacher.id,
+          },
+          {
+            status: ActivityStatus.SUBMITTED,
+            comment: 'Submitted for review.',
+            changedById: teacher.id,
+          },
+        ],
+      },
+    },
+  });
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/src-tauri/src/commands/activities.rs
+++ b/src-tauri/src/commands/activities.rs
@@ -1,0 +1,459 @@
+use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use rusqlite::{params, Row};
+use tauri::State;
+
+use crate::{
+    db::DbState,
+    error::{AppError, Result},
+    models::{
+        ActivityCommentDto, ActivityDto, ActivityFilters, ActivityInput, ActivityListResponse,
+        ActivityStatusHistoryDto, CommentInput, StatusTransitionInput, UserDto, UserSummaryDto,
+    },
+};
+
+fn to_utc(naive: NaiveDateTime) -> DateTime<Utc> {
+    Utc.from_utc_datetime(&naive)
+}
+
+fn get_user_role(conn: &rusqlite::Connection, user_id: i64) -> Result<String> {
+    conn.query_row(
+        "SELECT r.name FROM User u JOIN Role r ON u.roleId = r.id WHERE u.id = ?1",
+        params![user_id],
+        |row| row.get::<_, String>(0),
+    )
+    .map_err(|_| AppError::Unauthorized)
+}
+
+#[tauri::command]
+pub fn list_activities(
+    state: State<'_, DbState>,
+    actor_id: i64,
+    filters: Option<ActivityFilters>,
+) -> Result<ActivityListResponse> {
+    let conn = state.connection();
+    let actor_role = get_user_role(&conn, actor_id)?;
+    let status_filter = filters.as_ref().and_then(|f| f.status.clone());
+    let owner_filter = filters
+        .as_ref()
+        .and_then(|f| f.owner_id)
+        .filter(|_| actor_role != "TEACHER");
+
+    let sql = if actor_role == "TEACHER" {
+        "SELECT a.id, a.title, a.activityType, a.provider, a.activityDate, a.hours, a.reflection, a.status, \
+             owner.id, owner.email, owner.displayName, ownerRole.id, ownerRole.name, \
+             reviewer.id, reviewer.email, reviewer.displayName, reviewerRole.id, reviewerRole.name, \
+             a.goalId, a.createdAt, a.updatedAt, GROUP_CONCAT(DISTINCT t.name) \
+         FROM Activity a \
+         JOIN User owner ON owner.id = a.ownerId \
+         JOIN Role ownerRole ON ownerRole.id = owner.roleId \
+         LEFT JOIN User reviewer ON reviewer.id = a.reviewerId \
+         LEFT JOIN Role reviewerRole ON reviewerRole.id = reviewer.roleId \
+         LEFT JOIN ActivityTag at ON at.activityId = a.id \
+         LEFT JOIN Tag t ON t.id = at.tagId \
+         WHERE a.ownerId = ?1 AND (?2 IS NULL OR a.status = ?2) \
+         GROUP BY a.id \
+         ORDER BY a.activityDate DESC"
+            .to_string()
+    } else {
+        "SELECT a.id, a.title, a.activityType, a.provider, a.activityDate, a.hours, a.reflection, a.status, \
+             owner.id, owner.email, owner.displayName, ownerRole.id, ownerRole.name, \
+             reviewer.id, reviewer.email, reviewer.displayName, reviewerRole.id, reviewerRole.name, \
+             a.goalId, a.createdAt, a.updatedAt, GROUP_CONCAT(DISTINCT t.name) \
+         FROM Activity a \
+         JOIN User owner ON owner.id = a.ownerId \
+         JOIN Role ownerRole ON ownerRole.id = owner.roleId \
+         LEFT JOIN User reviewer ON reviewer.id = a.reviewerId \
+         LEFT JOIN Role reviewerRole ON reviewerRole.id = reviewer.roleId \
+         LEFT JOIN ActivityTag at ON at.activityId = a.id \
+         LEFT JOIN Tag t ON t.id = at.tagId \
+         WHERE (?1 IS NULL OR a.status = ?1) AND (?2 IS NULL OR a.ownerId = ?2) \
+         GROUP BY a.id \
+         ORDER BY a.activityDate DESC"
+            .to_string()
+    };
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = if actor_role == "TEACHER" {
+        stmt.query(params![actor_id, status_filter])?
+    } else {
+        stmt.query(params![status_filter, owner_filter])?
+    };
+
+    let mut activities = Vec::new();
+    while let Some(row) = rows.next()? {
+        activities.push(map_activity_row(&conn, &row)?);
+    }
+
+    Ok(ActivityListResponse { activities })
+}
+
+fn map_activity_row(conn: &rusqlite::Connection, row: &Row<'_>) -> Result<ActivityDto> {
+    let id: i64 = row.get(0)?;
+    let title: String = row.get(1)?;
+    let activity_type: String = row.get(2)?;
+    let provider: Option<String> = row.get(3)?;
+    let activity_date: NaiveDateTime = row.get(4)?;
+    let hours: f64 = row.get(5)?;
+    let reflection: Option<String> = row.get(6)?;
+    let status: String = row.get(7)?;
+    let owner = UserDto {
+        id: row.get(8)?,
+        email: row.get(9)?,
+        display_name: row.get(10)?,
+        role: crate::models::RoleDto {
+            id: row.get(11)?,
+            name: row.get(12)?,
+        },
+    };
+
+    let reviewer: Option<UserDto> = match row.get::<_, Option<i64>>(13)? {
+        Some(reviewer_id) => Some(UserDto {
+            id: reviewer_id,
+            email: row.get(14)?,
+            display_name: row.get(15)?,
+            role: crate::models::RoleDto {
+                id: row.get(16)?,
+                name: row.get(17)?,
+            },
+        }),
+        None => None,
+    };
+
+    let goal_id: Option<i64> = row.get(18)?;
+    let created_at: NaiveDateTime = row.get(19)?;
+    let updated_at: NaiveDateTime = row.get(20)?;
+    let tags: Option<String> = row.get(21)?;
+
+    let mut tag_list = Vec::new();
+    if let Some(tag_string) = tags {
+        tag_list = tag_string
+            .split(',')
+            .filter(|v| !v.is_empty())
+            .map(|v| v.trim().to_string())
+            .collect();
+    }
+
+    let status_history = fetch_status_history(conn, id)?;
+    let comments = fetch_comments(conn, id)?;
+
+    Ok(ActivityDto {
+        id,
+        title,
+        activity_type,
+        provider,
+        activity_date: activity_date.date(),
+        hours,
+        reflection,
+        status,
+        owner,
+        reviewer,
+        tags: tag_list,
+        goal_id,
+        created_at: to_utc(created_at),
+        updated_at: to_utc(updated_at),
+        status_history,
+        comments,
+    })
+}
+
+fn fetch_status_history(
+    conn: &rusqlite::Connection,
+    activity_id: i64,
+) -> Result<Vec<ActivityStatusHistoryDto>> {
+    let mut stmt = conn.prepare(
+        "SELECT h.id, h.status, h.comment, h.createdAt, u.id, u.displayName, r.name \
+         FROM ActivityStatusHistory h \
+         LEFT JOIN User u ON u.id = h.changedById \
+         LEFT JOIN Role r ON r.id = u.roleId \
+         WHERE h.activityId = ?1 ORDER BY h.createdAt ASC",
+    )?;
+    let mut rows = stmt.query(params![activity_id])?;
+    let mut entries = Vec::new();
+    while let Some(row) = rows.next()? {
+        let id: i64 = row.get(0)?;
+        let status: String = row.get(1)?;
+        let comment: Option<String> = row.get(2)?;
+        let created_at: NaiveDateTime = row.get(3)?;
+        let changed_by = match row.get::<_, Option<i64>>(4)? {
+            Some(user_id) => Some(UserSummaryDto {
+                id: user_id,
+                display_name: row.get(5)?,
+                role: row.get(6)?,
+            }),
+            None => None,
+        };
+        entries.push(ActivityStatusHistoryDto {
+            id,
+            status,
+            comment,
+            changed_by,
+            created_at: to_utc(created_at),
+        });
+    }
+    Ok(entries)
+}
+
+fn fetch_comments(
+    conn: &rusqlite::Connection,
+    activity_id: i64,
+) -> Result<Vec<ActivityCommentDto>> {
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.body, c.createdAt, u.id, u.displayName, r.name \
+         FROM ActivityComment c \
+         JOIN User u ON u.id = c.authorId \
+         JOIN Role r ON r.id = u.roleId \
+         WHERE c.activityId = ?1 ORDER BY c.createdAt ASC",
+    )?;
+    let mut rows = stmt.query(params![activity_id])?;
+    let mut comments = Vec::new();
+    while let Some(row) = rows.next()? {
+        let id: i64 = row.get(0)?;
+        let body: String = row.get(1)?;
+        let created_at: NaiveDateTime = row.get(2)?;
+        let author = UserSummaryDto {
+            id: row.get(3)?,
+            display_name: row.get(4)?,
+            role: row.get(5)?,
+        };
+        comments.push(ActivityCommentDto {
+            id,
+            body,
+            author,
+            created_at: to_utc(created_at),
+        });
+    }
+    Ok(comments)
+}
+
+#[tauri::command]
+pub fn create_activity(
+    state: State<'_, DbState>,
+    actor_id: i64,
+    input: ActivityInput,
+) -> Result<ActivityDto> {
+    validate_hours(input.hours)?;
+    let conn = state.connection();
+    let role = get_user_role(&conn, actor_id)?;
+    if role != "TEACHER" {
+        return Err(AppError::Unauthorized);
+    }
+
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "INSERT INTO Activity (title, activityType, provider, activityDate, hours, reflection, status, ownerId, goalId) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'DRAFT', ?7, ?8)",
+        params![
+            input.title,
+            input.activity_type,
+            input.provider,
+            input
+                .activity_date
+                .and_hms_opt(0, 0, 0)
+                .ok_or_else(|| AppError::validation("Invalid activity date."))?,
+            input.hours,
+            input.reflection,
+            actor_id,
+            input.goal_id,
+        ],
+    )?;
+
+    let activity_id = tx.last_insert_rowid();
+    update_tags(tx.conn(), activity_id, &input.tags)?;
+    tx.execute(
+        "INSERT INTO ActivityStatusHistory (activityId, status, comment, changedById) VALUES (?1, 'DRAFT', 'Created draft', ?2)",
+        params![activity_id, actor_id],
+    )?;
+    tx.commit()?;
+
+    let mut stmt = conn.prepare("SELECT a.id, a.title, a.activityType, a.provider, a.activityDate, a.hours, a.reflection, a.status, owner.id, owner.email, owner.displayName, ownerRole.id, ownerRole.name, reviewer.id, reviewer.email, reviewer.displayName, reviewerRole.id, reviewerRole.name, a.goalId, a.createdAt, a.updatedAt, GROUP_CONCAT(DISTINCT t.name) FROM Activity a JOIN User owner ON owner.id = a.ownerId JOIN Role ownerRole ON ownerRole.id = owner.roleId LEFT JOIN User reviewer ON reviewer.id = a.reviewerId LEFT JOIN Role reviewerRole ON reviewerRole.id = reviewer.roleId LEFT JOIN ActivityTag at ON at.activityId = a.id LEFT JOIN Tag t ON t.id = at.tagId WHERE a.id = ?1 GROUP BY a.id")?;
+    let activity_row = stmt.query_row(params![activity_id], |row| map_activity_row(&conn, row))?;
+    Ok(activity_row)
+}
+
+fn update_tags(conn: &rusqlite::Connection, activity_id: i64, tags: &[String]) -> Result<()> {
+    conn.execute(
+        "DELETE FROM ActivityTag WHERE activityId = ?1",
+        params![activity_id],
+    )?;
+    for tag in tags {
+        if tag.trim().is_empty() {
+            continue;
+        }
+        let tag_id = ensure_tag(conn, tag)?;
+        conn.execute(
+            "INSERT OR IGNORE INTO ActivityTag (activityId, tagId) VALUES (?1, ?2)",
+            params![activity_id, tag_id],
+        )?;
+    }
+    Ok(())
+}
+
+fn ensure_tag(conn: &rusqlite::Connection, tag: &str) -> Result<i64> {
+    conn.execute("INSERT OR IGNORE INTO Tag (name) VALUES (?1)", params![tag])?;
+    conn.query_row("SELECT id FROM Tag WHERE name = ?1", params![tag], |row| {
+        row.get(0)
+    })
+    .map_err(Into::into)
+}
+
+#[tauri::command]
+pub fn update_activity(
+    state: State<'_, DbState>,
+    actor_id: i64,
+    activity_id: i64,
+    input: ActivityInput,
+) -> Result<ActivityDto> {
+    validate_hours(input.hours)?;
+    let conn = state.connection();
+    let role = get_user_role(&conn, actor_id)?;
+    let status: String = conn
+        .query_row(
+            "SELECT status FROM Activity WHERE id = ?1 AND ownerId = ?2",
+            params![activity_id, actor_id],
+            |row| row.get(0),
+        )
+        .map_err(|_| AppError::Unauthorized)?;
+
+    if role == "TEACHER" && status != "DRAFT" {
+        return Err(AppError::validation(
+            "Activities can only be edited while in DRAFT status.",
+        ));
+    }
+
+    if role != "TEACHER" && role != "ADMIN" {
+        return Err(AppError::Unauthorized);
+    }
+
+    conn.execute(
+        "UPDATE Activity SET title = ?1, activityType = ?2, provider = ?3, activityDate = ?4, hours = ?5, reflection = ?6, goalId = ?7 WHERE id = ?8",
+        params![
+            input.title,
+            input.activity_type,
+            input.provider,
+            input
+                .activity_date
+                .and_hms_opt(0, 0, 0)
+                .ok_or_else(|| AppError::validation("Invalid activity date."))?,
+            input.hours,
+            input.reflection,
+            input.goal_id,
+            activity_id,
+        ],
+    )?;
+
+    update_tags(&conn, activity_id, &input.tags)?;
+    fetch_activity_by_id(&conn, activity_id)
+}
+
+fn fetch_activity_by_id(conn: &rusqlite::Connection, activity_id: i64) -> Result<ActivityDto> {
+    let mut stmt = conn.prepare(
+        "SELECT a.id, a.title, a.activityType, a.provider, a.activityDate, a.hours, a.reflection, a.status, \
+            owner.id, owner.email, owner.displayName, ownerRole.id, ownerRole.name, \
+            reviewer.id, reviewer.email, reviewer.displayName, reviewerRole.id, reviewerRole.name, \
+            a.goalId, a.createdAt, a.updatedAt, GROUP_CONCAT(DISTINCT t.name) \
+        FROM Activity a \
+        JOIN User owner ON owner.id = a.ownerId \
+        JOIN Role ownerRole ON ownerRole.id = owner.roleId \
+        LEFT JOIN User reviewer ON reviewer.id = a.reviewerId \
+        LEFT JOIN Role reviewerRole ON reviewerRole.id = reviewer.roleId \
+        LEFT JOIN ActivityTag at ON at.activityId = a.id \
+        LEFT JOIN Tag t ON t.id = at.tagId \
+        WHERE a.id = ?1 \
+        GROUP BY a.id",
+    )?;
+    stmt.query_row(params![activity_id], |row| map_activity_row(conn, row))
+        .map_err(|_| AppError::NotFound)
+}
+
+#[tauri::command]
+pub fn delete_activity(state: State<'_, DbState>, actor_id: i64, activity_id: i64) -> Result<()> {
+    let conn = state.connection();
+    let status: String = conn
+        .query_row(
+            "SELECT status FROM Activity WHERE id = ?1 AND ownerId = ?2",
+            params![activity_id, actor_id],
+            |row| row.get(0),
+        )
+        .map_err(|_| AppError::Unauthorized)?;
+
+    if status != "DRAFT" {
+        return Err(AppError::validation(
+            "Only draft activities can be deleted by the owner.",
+        ));
+    }
+
+    conn.execute("DELETE FROM Activity WHERE id = ?1", params![activity_id])?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn transition_activity_status(
+    state: State<'_, DbState>,
+    actor_id: i64,
+    payload: StatusTransitionInput,
+) -> Result<ActivityDto> {
+    let conn = state.connection();
+    let role = get_user_role(&conn, actor_id)?;
+    let current: (String, i64) = conn
+        .query_row(
+            "SELECT status, ownerId FROM Activity WHERE id = ?1",
+            params![payload.activity_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .map_err(|_| AppError::NotFound)?;
+
+    let next_status = payload.status.to_uppercase();
+    match (current.0.as_str(), next_status.as_str()) {
+        ("DRAFT", "SUBMITTED") if current.1 == actor_id && role == "TEACHER" => {}
+        ("SUBMITTED", "APPROVED") | ("SUBMITTED", "REJECTED") if role != "TEACHER" => {}
+        _ => {
+            return Err(AppError::validation(
+                "Status transition not permitted for the current user.",
+            ))
+        }
+    }
+
+    conn.execute(
+        "UPDATE Activity SET status = ?1, reviewerId = CASE WHEN ?1 IN ('APPROVED','REJECTED') THEN ?2 ELSE reviewerId END WHERE id = ?3",
+        params![next_status, actor_id, payload.activity_id],
+    )?;
+
+    conn.execute(
+        "INSERT INTO ActivityStatusHistory (activityId, status, comment, changedById) VALUES (?1, ?2, ?3, ?4)",
+        params![
+            payload.activity_id,
+            next_status,
+            payload.comment,
+            actor_id,
+        ],
+    )?;
+
+    fetch_activity_by_id(&conn, payload.activity_id)
+}
+
+#[tauri::command]
+pub fn add_comment(
+    state: State<'_, DbState>,
+    actor_id: i64,
+    payload: CommentInput,
+) -> Result<ActivityDto> {
+    let conn = state.connection();
+    conn.execute(
+        "INSERT INTO ActivityComment (activityId, authorId, body) VALUES (?1, ?2, ?3)",
+        params![payload.activity_id, actor_id, payload.body],
+    )?;
+
+    fetch_activity_by_id(&conn, payload.activity_id)
+}
+
+fn validate_hours(hours: f64) -> Result<()> {
+    if hours <= 0.0 {
+        return Err(AppError::validation("Hours must be greater than zero."));
+    }
+    if hours > 24.0 {
+        return Err(AppError::validation(
+            "Activities longer than 24 hours must be split into multiple entries.",
+        ));
+    }
+    Ok(())
+}

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1,0 +1,55 @@
+use bcrypt::verify;
+use rusqlite::params;
+use tauri::State;
+
+use crate::{
+    db::DbState,
+    error::{AppError, Result},
+    models::{LoginRequest, LoginResponse, RoleDto, UserDto},
+};
+
+#[tauri::command]
+pub fn login(state: State<'_, DbState>, payload: LoginRequest) -> Result<LoginResponse> {
+    let conn = state.connection();
+    let mut stmt = conn.prepare(
+        "SELECT u.id, u.email, u.passwordHash, u.displayName, r.id, r.name \
+         FROM User u JOIN Role r ON u.roleId = r.id WHERE LOWER(u.email) = LOWER(?1)",
+    )?;
+
+    let row = stmt
+        .query_row(params![payload.email], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, String>(5)?,
+            ))
+        })
+        .map_err(|_| AppError::Unauthorized)?;
+
+    let password_matches = verify(payload.password, &row.2)
+        .map_err(|err| AppError::Other(format!("failed to verify password: {err}")))?;
+
+    if !password_matches {
+        return Err(AppError::Unauthorized);
+    }
+
+    let role = RoleDto {
+        id: row.4,
+        name: row.5,
+    };
+
+    let user = UserDto {
+        id: row.0,
+        email: row.1,
+        display_name: row.3,
+        role,
+    };
+
+    Ok(LoginResponse {
+        token: format!("local-{}", user.id),
+        user,
+    })
+}

--- a/src-tauri/src/commands/goals.rs
+++ b/src-tauri/src/commands/goals.rs
@@ -1,0 +1,30 @@
+use rusqlite::params;
+use tauri::State;
+
+use crate::{
+    db::DbState,
+    error::{AppError, Result},
+    models::YearlyGoalDto,
+};
+
+#[tauri::command]
+pub fn list_goals(state: State<'_, DbState>, user_id: i64) -> Result<Vec<YearlyGoalDto>> {
+    let conn = state.connection();
+    let mut stmt = conn.prepare(
+        "SELECT id, year, targetHours, notes FROM YearlyGoal WHERE userId = ?1 ORDER BY year DESC",
+    )?;
+    let mut rows = stmt.query(params![user_id])?;
+    let mut goals = Vec::new();
+    while let Some(row) = rows.next()? {
+        goals.push(YearlyGoalDto {
+            id: row.get(0)?,
+            year: row.get(1)?,
+            target_hours: row.get(2)?,
+            notes: row.get(3)?,
+        });
+    }
+    if goals.is_empty() {
+        return Err(AppError::NotFound);
+    }
+    Ok(goals)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,0 +1,7 @@
+pub mod activities;
+pub mod auth;
+pub mod goals;
+
+pub use activities::*;
+pub use auth::*;
+pub use goals::*;

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,0 +1,245 @@
+use std::path::PathBuf;
+
+use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use parking_lot::Mutex;
+use rusqlite::{params, Connection, OpenFlags};
+use tauri::AppHandle;
+
+use crate::error::{AppError, Result};
+
+pub struct DbState {
+    conn: Mutex<Connection>,
+    pub db_path: PathBuf,
+}
+
+impl DbState {
+    pub fn initialize(app_handle: &AppHandle) -> Result<Self> {
+        let app_dir = tauri::api::path::app_data_dir(app_handle.config())
+            .ok_or_else(|| AppError::Other("could not determine app data directory".into()))?;
+        std::fs::create_dir_all(&app_dir)?;
+        let db_path = app_dir.join("activities.db");
+        let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_FULL_MUTEX;
+        let mut conn = Connection::open_with_flags(&db_path, flags)?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+
+        std::env::set_var(
+            "DATABASE_URL",
+            format!("file:{}", db_path.to_string_lossy()),
+        );
+
+        let version: i64 = conn.pragma_query_value(None, "user_version", |row| row.get(0))?;
+        if version == 0 {
+            run_migrations(&mut conn)?;
+            conn.pragma_update(None, "user_version", &1)?;
+            seed_defaults(&mut conn)?;
+        }
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+            db_path,
+        })
+    }
+
+    pub fn connection(&self) -> parking_lot::MutexGuard<'_, Connection> {
+        self.conn.lock()
+    }
+}
+
+fn run_migrations(conn: &mut Connection) -> Result<()> {
+    let migration_sql = include_str!("../prisma/migrations/20240101000000_init/migration.sql");
+    conn.execute_batch(migration_sql)?;
+    Ok(())
+}
+
+fn seed_defaults(conn: &mut Connection) -> Result<()> {
+    let tx = conn.transaction()?;
+    for role in ["TEACHER", "SUPERVISOR", "ADMIN"] {
+        tx.execute(
+            "INSERT OR IGNORE INTO Role (name) VALUES (?1)",
+            params![role],
+        )?;
+    }
+
+    let teacher_role_id: i64 =
+        tx.query_row("SELECT id FROM Role WHERE name = 'TEACHER'", [], |row| {
+            row.get(0)
+        })?;
+    let supervisor_role_id: i64 =
+        tx.query_row("SELECT id FROM Role WHERE name = 'SUPERVISOR'", [], |row| {
+            row.get(0)
+        })?;
+    let admin_role_id: i64 =
+        tx.query_row("SELECT id FROM Role WHERE name = 'ADMIN'", [], |row| {
+            row.get(0)
+        })?;
+
+    let hashed_password = bcrypt::hash("password123", 10)
+        .map_err(|err| AppError::Other(format!("failed to hash password: {err}")))?;
+
+    tx.execute(
+        "INSERT OR IGNORE INTO User (email, passwordHash, displayName, roleId) VALUES (?1, ?2, ?3, ?4)",
+        params![
+            "teacher@example.com",
+            hashed_password.as_str(),
+            "Taylor Teacher",
+            teacher_role_id,
+        ],
+    )?;
+
+    tx.execute(
+        "INSERT OR IGNORE INTO User (email, passwordHash, displayName, roleId) VALUES (?1, ?2, ?3, ?4)",
+        params![
+            "supervisor@example.com",
+            hashed_password.as_str(),
+            "Sam Supervisor",
+            supervisor_role_id,
+        ],
+    )?;
+
+    tx.execute(
+        "INSERT OR IGNORE INTO User (email, passwordHash, displayName, roleId) VALUES (?1, ?2, ?3, ?4)",
+        params![
+            "admin@example.com",
+            hashed_password.as_str(),
+            "Ada Admin",
+            admin_role_id,
+        ],
+    )?;
+
+    tx.execute(
+        "INSERT OR IGNORE INTO RubricConfiguration (id, name, description, weight, active) VALUES (1, ?1, ?2, ?3, 1)",
+        params![
+            "Impact",
+            "How the activity impacts learners or community.",
+            0.4f64,
+        ],
+    )?;
+
+    tx.execute(
+        "INSERT OR IGNORE INTO RubricConfiguration (id, name, description, weight, active) VALUES (2, ?1, ?2, ?3, 1)",
+        params![
+            "Reflection",
+            "Quality of reflection submitted by the educator.",
+            0.3f64,
+        ],
+    )?;
+
+    tx.execute(
+        "INSERT OR IGNORE INTO RubricConfiguration (id, name, description, weight, active) VALUES (3, ?1, ?2, ?3, 1)",
+        params![
+            "Evidence",
+            "Strength of supporting evidence provided.",
+            0.3f64,
+        ],
+    )?;
+
+    let current_year = chrono::Utc::now().year();
+    let teacher_id: i64 = tx.query_row(
+        "SELECT id FROM User WHERE email = 'teacher@example.com'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    tx.execute(
+        "INSERT OR IGNORE INTO YearlyGoal (userId, year, targetHours, notes) VALUES (?1, ?2, ?3, ?4)",
+        params![
+            teacher_id,
+            current_year,
+            40.0f64,
+            "Default target for professional development.",
+        ],
+    )?;
+
+    let supervisor_id: i64 = tx.query_row(
+        "SELECT id FROM User WHERE email = 'supervisor@example.com'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    let goal_id: i64 = tx.query_row(
+        "SELECT id FROM YearlyGoal WHERE userId = ?1 AND year = ?2",
+        params![teacher_id, current_year],
+        |row| row.get(0),
+    )?;
+
+    tx.execute(
+        "INSERT OR IGNORE INTO Activity (id, title, activityType, provider, activityDate, hours, reflection, status, ownerId, reviewerId, goalId) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        params![
+            "STEM Workshop",
+            "PROFESSIONAL_DEVELOPMENT",
+            "Local University",
+            NaiveDateTime::new(NaiveDate::from_ymd_opt(current_year, 1, 15).unwrap(), chrono::NaiveTime::from_hms_opt(9, 0, 0).unwrap()),
+            4.0f64,
+            "Great opportunity to collaborate with peers.",
+            "SUBMITTED",
+            teacher_id,
+            supervisor_id,
+            goal_id,
+        ],
+    )?;
+
+    let activity_exists: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM ActivityTag WHERE activityId = 1",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if activity_exists == 0 {
+        let stem_tag_id = ensure_tag(&tx, "STEM")?;
+        let workshop_tag_id = ensure_tag(&tx, "Workshop")?;
+        tx.execute(
+            "INSERT OR IGNORE INTO ActivityTag (activityId, tagId) VALUES (1, ?1)",
+            params![stem_tag_id],
+        )?;
+        tx.execute(
+            "INSERT OR IGNORE INTO ActivityTag (activityId, tagId) VALUES (1, ?1)",
+            params![workshop_tag_id],
+        )?;
+    }
+
+    let history_count: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM ActivityStatusHistory WHERE activityId = 1",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if history_count == 0 {
+        let now = Utc::now();
+        tx.execute(
+            "INSERT INTO ActivityStatusHistory (activityId, status, comment, changedById, createdAt) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                1,
+                "DRAFT",
+                "Initial draft created.",
+                teacher_id,
+                now,
+            ],
+        )?;
+        tx.execute(
+            "INSERT INTO ActivityStatusHistory (activityId, status, comment, changedById, createdAt) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                1,
+                "SUBMITTED",
+                "Submitted for review.",
+                teacher_id,
+                now,
+            ],
+        )?;
+    }
+
+    tx.commit()?;
+    Ok(())
+}
+
+fn ensure_tag(conn: &Connection, name: &str) -> Result<i64> {
+    conn.execute(
+        "INSERT OR IGNORE INTO Tag (name) VALUES (?1)",
+        params![name],
+    )?;
+    let id = conn.query_row("SELECT id FROM Tag WHERE name = ?1", params![name], |row| {
+        row.get(0)
+    })?;
+    Ok(id)
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,42 @@
+use std::fmt::Display;
+
+use serde::Serialize;
+use tauri::InvokeError;
+
+pub type Result<T> = std::result::Result<T, AppError>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum AppError {
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("validation error: {0}")]
+    Validation(String),
+    #[error("not found")]
+    NotFound,
+    #[error("unauthorized")]
+    Unauthorized,
+    #[error("internal error: {0}")]
+    Other(String),
+}
+
+#[derive(Serialize)]
+pub struct ErrorResponse {
+    pub message: String,
+}
+
+impl From<AppError> for InvokeError {
+    fn from(value: AppError) -> Self {
+        InvokeError::from_serde(ErrorResponse {
+            message: value.to_string(),
+        })
+        .unwrap_or_else(|_| InvokeError::from_anyhow(anyhow::anyhow!(value.to_string())))
+    }
+}
+
+impl AppError {
+    pub fn validation<T: Display>(msg: T) -> Self {
+        AppError::Validation(msg.to_string())
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,35 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+mod commands;
+mod db;
+mod error;
+mod models;
+
+use commands::{
+    add_comment, create_activity, delete_activity, list_activities, list_goals, login,
+    transition_activity_status, update_activity,
+};
+use db::DbState;
+
+fn main() {
+    tauri::Builder::default()
+        .setup(|app| {
+            let handle = app.handle();
+            let db =
+                DbState::initialize(&handle).map_err(|err| anyhow::anyhow!(err.to_string()))?;
+            app.manage(db);
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            login,
+            list_activities,
+            create_activity,
+            update_activity,
+            delete_activity,
+            transition_activity_status,
+            add_comment,
+            list_goals
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,0 +1,138 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleDto {
+    pub id: i64,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UserDto {
+    pub id: i64,
+    pub email: String,
+    pub display_name: String,
+    pub role: RoleDto,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityDto {
+    pub id: i64,
+    pub title: String,
+    pub activity_type: String,
+    pub provider: Option<String>,
+    pub activity_date: NaiveDate,
+    pub hours: f64,
+    pub reflection: Option<String>,
+    pub status: String,
+    pub owner: UserDto,
+    pub reviewer: Option<UserDto>,
+    pub tags: Vec<String>,
+    pub goal_id: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub status_history: Vec<ActivityStatusHistoryDto>,
+    pub comments: Vec<ActivityCommentDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityStatusHistoryDto {
+    pub id: i64,
+    pub status: String,
+    pub comment: Option<String>,
+    pub changed_by: Option<UserSummaryDto>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityCommentDto {
+    pub id: i64,
+    pub body: String,
+    pub author: UserSummaryDto,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UserSummaryDto {
+    pub id: i64,
+    pub display_name: String,
+    pub role: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoginRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoginResponse {
+    pub token: String,
+    pub user: UserDto,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityInput {
+    pub title: String,
+    pub activity_type: String,
+    pub provider: Option<String>,
+    pub activity_date: NaiveDate,
+    pub hours: f64,
+    pub reflection: Option<String>,
+    pub tags: Vec<String>,
+    pub goal_id: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityUpdateInput {
+    pub id: i64,
+    #[serde(flatten)]
+    pub payload: ActivityInput,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusTransitionInput {
+    pub activity_id: i64,
+    pub status: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommentInput {
+    pub activity_id: i64,
+    pub body: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct YearlyGoalDto {
+    pub id: i64,
+    pub year: i64,
+    pub target_hours: f64,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityFilters {
+    pub status: Option<String>,
+    pub owner_id: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityListResponse {
+    pub activities: Vec<ActivityDto>,
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeDevCommand": "pnpm dev",
+    "beforeBuildCommand": "pnpm build",
+    "devPath": "http://localhost:5173",
+    "distDir": "../dist"
+  },
+  "package": {
+    "productName": "KRUchat",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "active": true,
+      "targets": "all",
+      "identifier": "io.kruchat.app"
+    },
+    "windows": [
+      {
+        "title": "KRUchat Activity Tracker",
+        "width": 1200,
+        "height": 780
+      }
+    ]
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { AuthProvider, useAuth } from './context/AuthContext';
+import LoginView from './components/LoginView';
+import Dashboard from './components/Dashboard';
+
+const Shell: React.FC = () => {
+  const { user } = useAuth();
+  return user ? <Dashboard /> : <LoginView />;
+};
+
+const App: React.FC = () => (
+  <AuthProvider>
+    <Shell />
+  </AuthProvider>
+);
+
+export default App;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,75 @@
+import { invoke } from '@tauri-apps/api/tauri';
+import {
+  ActivityDto,
+  ActivityFilters,
+  ActivityInput,
+  ActivityStatus,
+  ActivityType,
+  LoginResponse,
+  YearlyGoalDto,
+} from './types';
+
+export async function authenticate(email: string, password: string): Promise<LoginResponse> {
+  return invoke<LoginResponse>('login', { payload: { email, password } });
+}
+
+export async function fetchActivities(actorId: number, filters?: ActivityFilters): Promise<ActivityDto[]> {
+  const response = await invoke<{ activities: ActivityDto[] }>('list_activities', {
+    actorId,
+    filters,
+  });
+  return response.activities;
+}
+
+export async function createActivity(actorId: number, input: ActivityInput): Promise<ActivityDto> {
+  return invoke<ActivityDto>('create_activity', { actorId, input });
+}
+
+export async function updateActivity(
+  actorId: number,
+  activityId: number,
+  input: ActivityInput,
+): Promise<ActivityDto> {
+  return invoke<ActivityDto>('update_activity', { actorId, activityId, input });
+}
+
+export async function deleteActivity(actorId: number, activityId: number): Promise<void> {
+  await invoke('delete_activity', { actorId, activityId });
+}
+
+export async function transitionStatus(
+  actorId: number,
+  activityId: number,
+  status: ActivityStatus,
+  comment?: string,
+): Promise<ActivityDto> {
+  return invoke<ActivityDto>('transition_activity_status', {
+    actorId,
+    payload: {
+      activityId,
+      status,
+      comment,
+    },
+  });
+}
+
+export async function addComment(actorId: number, activityId: number, body: string): Promise<ActivityDto> {
+  return invoke<ActivityDto>('add_comment', {
+    actorId,
+    payload: {
+      activityId,
+      body,
+    },
+  });
+}
+
+export async function fetchGoals(userId: number): Promise<YearlyGoalDto[]> {
+  return invoke<YearlyGoalDto[]>('list_goals', { userId });
+}
+
+export const ACTIVITY_TYPES: ActivityType[] = [
+  'SERVICE',
+  'PROFESSIONAL_DEVELOPMENT',
+  'COMMUNITY',
+  'OTHER',
+];

--- a/src/components/ActivityForm.tsx
+++ b/src/components/ActivityForm.tsx
@@ -1,0 +1,144 @@
+import React, { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ACTIVITY_TYPES } from '../api';
+import { ActivityDto, ActivityInput, ActivityType, YearlyGoalDto } from '../types';
+
+const schema = z.object({
+  title: z.string().min(3, 'Title must be at least 3 characters.'),
+  activityType: z.enum(['SERVICE', 'PROFESSIONAL_DEVELOPMENT', 'COMMUNITY', 'OTHER']),
+  provider: z.string().optional(),
+  activityDate: z.string().min(1, 'Date is required.'),
+  hours: z
+    .number({ invalid_type_error: 'Enter a number of hours.' })
+    .positive('Hours must be greater than zero.')
+    .max(24, 'Split large activities into multiple entries.'),
+  tags: z.string().optional(),
+  reflection: z.string().optional(),
+  goalId: z.union([z.number(), z.nan()]).optional(),
+});
+
+export type ActivityFormValues = z.infer<typeof schema>;
+
+interface ActivityFormProps {
+  initial?: ActivityDto | null;
+  goals: YearlyGoalDto[];
+  onSubmit: (input: ActivityInput) => Promise<void>;
+  onCancel?: () => void;
+  submitLabel?: string;
+}
+
+const ActivityForm: React.FC<ActivityFormProps> = ({ initial, goals, onSubmit, onCancel, submitLabel }) => {
+  const defaultValues: ActivityFormValues = useMemo(
+    () => ({
+      title: initial?.title ?? '',
+      activityType: initial?.activityType ?? 'PROFESSIONAL_DEVELOPMENT',
+      provider: initial?.provider ?? '',
+      activityDate: initial?.activityDate ?? new Date().toISOString().slice(0, 10),
+      hours: initial?.hours ?? 1,
+      tags: initial?.tags.join(', ') ?? '',
+      reflection: initial?.reflection ?? '',
+      goalId: initial?.goalId ?? Number.NaN,
+    }),
+    [initial],
+  );
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<ActivityFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues,
+  });
+
+  const onFormSubmit = handleSubmit(async (values) => {
+    const payload: ActivityInput = {
+      title: values.title,
+      activityType: values.activityType as ActivityType,
+      provider: values.provider || undefined,
+      activityDate: values.activityDate,
+      hours: values.hours,
+      tags: values.tags
+        ? values.tags
+            .split(',')
+            .map((tag) => tag.trim())
+            .filter(Boolean)
+        : [],
+      reflection: values.reflection || undefined,
+      goalId: Number.isNaN(values.goalId) ? undefined : values.goalId,
+    };
+    await onSubmit(payload);
+    if (!initial) {
+      reset(defaultValues);
+    }
+  });
+
+  return (
+    <form className="card" onSubmit={onFormSubmit}>
+      <h2>{initial ? 'Update Activity' : 'Log a New Activity'}</h2>
+      <label>
+        Title
+        <input type="text" {...register('title')} />
+        {errors.title && <span className="error">{errors.title.message}</span>}
+      </label>
+      <label>
+        Activity Type
+        <select {...register('activityType')}>
+          {ACTIVITY_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type.replace(/_/g, ' ')}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Provider
+        <input type="text" {...register('provider')} />
+      </label>
+      <label>
+        Date
+        <input type="date" {...register('activityDate')} />
+        {errors.activityDate && <span className="error">{errors.activityDate.message}</span>}
+      </label>
+      <label>
+        Hours
+        <input type="number" step="0.25" min="0" {...register('hours', { valueAsNumber: true })} />
+        {errors.hours && <span className="error">{errors.hours.message}</span>}
+      </label>
+      <label>
+        Tags (comma separated)
+        <input type="text" placeholder="STEM, Workshop" {...register('tags')} />
+      </label>
+      <label>
+        Reflection
+        <textarea rows={4} {...register('reflection')} />
+      </label>
+      <label>
+        Align to Goal
+        <select {...register('goalId', { valueAsNumber: true })}>
+          <option value="">None</option>
+          {goals.map((goal) => (
+            <option key={goal.id} value={goal.id}>
+              {goal.year} Goal — {goal.targetHours} hrs target
+            </option>
+          ))}
+        </select>
+      </label>
+      <div className="actions">
+        {onCancel && (
+          <button type="button" className="ghost" onClick={onCancel}>
+            Cancel
+          </button>
+        )}
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Saving…' : submitLabel ?? (initial ? 'Save Changes' : 'Create Activity')}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ActivityForm;

--- a/src/components/ActivityTable.tsx
+++ b/src/components/ActivityTable.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { ActivityDto, ActivityStatus } from '../types';
+
+interface ActivityTableProps {
+  activities: ActivityDto[];
+  onEdit: (activity: ActivityDto) => void;
+  onDelete: (activity: ActivityDto) => void;
+  onSubmitDraft: (activity: ActivityDto) => void;
+  onTransition: (activity: ActivityDto, status: ActivityStatus) => void;
+  onAddComment: (activity: ActivityDto) => void;
+  canApprove: boolean;
+  userId: number;
+}
+
+const ActivityTable: React.FC<ActivityTableProps> = ({
+  activities,
+  onEdit,
+  onDelete,
+  onSubmitDraft,
+  onTransition,
+  onAddComment,
+  canApprove,
+  userId,
+}) => {
+  if (!activities.length) {
+    return <p className="muted">No activities yet. Use the form above to add your first entry.</p>;
+  }
+
+  return (
+    <div className="grid">
+      {activities.map((activity) => {
+        const isOwner = activity.owner.id === userId;
+        return (
+          <article className="card activity" key={activity.id}>
+            <header>
+              <div>
+                <h3>{activity.title}</h3>
+                <p className="muted">
+                  {new Date(activity.activityDate).toLocaleDateString()} • {activity.activityType.replace(/_/g, ' ')} •{' '}
+                  {activity.hours} hrs
+                </p>
+              </div>
+              <span className={`status status-${activity.status.toLowerCase()}`}>{activity.status}</span>
+            </header>
+            {activity.provider && <p className="muted">Provider: {activity.provider}</p>}
+            {activity.tags.length > 0 && (
+              <p className="tags">
+                {activity.tags.map((tag) => (
+                  <span key={tag}>{tag}</span>
+                ))}
+              </p>
+            )}
+            {activity.reflection && <p className="reflection">“{activity.reflection}”</p>}
+            <section className="history">
+              <strong>Workflow</strong>
+              <ul>
+                {activity.statusHistory.map((entry) => (
+                  <li key={entry.id}>
+                    <span>{entry.status}</span>
+                    <small>
+                      {new Date(entry.createdAt).toLocaleString()} by {entry.changedBy?.displayName ?? 'System'}
+                    </small>
+                    {entry.comment && <p className="muted">{entry.comment}</p>}
+                  </li>
+                ))}
+              </ul>
+            </section>
+            <section className="history">
+              <strong>Comments</strong>
+              <ul>
+                {activity.comments.length === 0 && <li className="muted">No comments yet.</li>}
+                {activity.comments.map((comment) => (
+                  <li key={comment.id}>
+                    <span>{comment.author.displayName}</span>
+                    <small>{new Date(comment.createdAt).toLocaleString()}</small>
+                    <p>{comment.body}</p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+            <footer>
+              <div className="actions">
+                {isOwner && activity.status === 'DRAFT' && (
+                  <>
+                    <button onClick={() => onEdit(activity)}>Edit</button>
+                    <button className="primary" onClick={() => onSubmitDraft(activity)}>
+                      Submit for Review
+                    </button>
+                    <button className="ghost" onClick={() => onDelete(activity)}>
+                      Delete
+                    </button>
+                  </>
+                )}
+                {canApprove && activity.status === 'SUBMITTED' && (
+                  <>
+                    <button className="primary" onClick={() => onTransition(activity, 'APPROVED')}>
+                      Approve
+                    </button>
+                    <button className="ghost" onClick={() => onTransition(activity, 'REJECTED')}>
+                      Reject
+                    </button>
+                  </>
+                )}
+                <button onClick={() => onAddComment(activity)}>Add Comment</button>
+              </div>
+            </footer>
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ActivityTable;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,178 @@
+import React, { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  addComment,
+  createActivity,
+  deleteActivity,
+  fetchActivities,
+  fetchGoals,
+  transitionStatus,
+  updateActivity,
+} from '../api';
+import ActivityForm from './ActivityForm';
+import ActivityTable from './ActivityTable';
+import { useAuth } from '../context/AuthContext';
+import { ActivityDto, ActivityInput, ActivityStatus, YearlyGoalDto } from '../types';
+
+const Dashboard: React.FC = () => {
+  const { user, logout, hasRole } = useAuth();
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState<ActivityDto | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const activityQuery = useQuery({
+    queryKey: ['activities', user?.id],
+    queryFn: () => fetchActivities(user!.id),
+    enabled: !!user,
+  });
+
+  const goalsQuery = useQuery({
+    queryKey: ['goals', user?.id],
+    queryFn: () => fetchGoals(user!.id),
+    enabled: !!user && hasRole('TEACHER'),
+    retry: false,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (input: ActivityInput) => createActivity(user!.id, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['activities', user?.id] });
+      setFeedback('Activity created successfully.');
+    },
+    onError: (error: unknown) => setFeedback((error as Error).message ?? 'Failed to create activity.'),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (variables: { id: number; payload: ActivityInput }) =>
+      updateActivity(user!.id, variables.id, variables.payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['activities', user?.id] });
+      setFeedback('Activity updated.');
+      setEditing(null);
+    },
+    onError: (error: unknown) => setFeedback((error as Error).message ?? 'Failed to update activity.'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (activityId: number) => deleteActivity(user!.id, activityId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['activities', user?.id] });
+      setFeedback('Activity deleted.');
+    },
+    onError: (error: unknown) => setFeedback((error as Error).message ?? 'Unable to delete activity.'),
+  });
+
+  const transitionMutation = useMutation({
+    mutationFn: (variables: { id: number; status: ActivityStatus; comment?: string }) =>
+      transitionStatus(user!.id, variables.id, variables.status, variables.comment),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['activities', user?.id] });
+      setFeedback('Status updated.');
+      setEditing(null);
+    },
+    onError: (error: unknown) => setFeedback((error as Error).message ?? 'Status change failed.'),
+  });
+
+  const commentMutation = useMutation({
+    mutationFn: (variables: { id: number; message: string }) => addComment(user!.id, variables.id, variables.message),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['activities', user?.id] });
+      setFeedback('Comment added.');
+    },
+    onError: (error: unknown) => setFeedback((error as Error).message ?? 'Failed to add comment.'),
+  });
+
+  const goals = useMemo<YearlyGoalDto[]>(() => goalsQuery.data ?? [], [goalsQuery.data]);
+
+  const handleSubmit = async (payload: ActivityInput) => {
+    if (editing) {
+      await updateMutation.mutateAsync({ id: editing.id, payload });
+    } else {
+      await createMutation.mutateAsync(payload);
+    }
+  };
+
+  const handleSubmitDraft = (activity: ActivityDto) => {
+    const comment = window.prompt('Add a note for your reviewer (optional):');
+    transitionMutation.mutate({ id: activity.id, status: 'SUBMITTED', comment: comment || undefined });
+  };
+
+  const handleApproval = (activity: ActivityDto, status: ActivityStatus) => {
+    const comment = window.prompt('Leave a comment for the educator (optional):');
+    transitionMutation.mutate({ id: activity.id, status, comment: comment || undefined });
+  };
+
+  const handleAddComment = (activity: ActivityDto) => {
+    const comment = window.prompt('Share feedback on this activity:');
+    if (comment) {
+      commentMutation.mutate({ id: activity.id, message: comment });
+    }
+  };
+
+  const loading = activityQuery.isLoading || goalsQuery.isLoading;
+  const errorMessage = (activityQuery.error as Error)?.message ?? null;
+
+  return (
+    <div className="layout">
+      <header className="top-bar">
+        <div>
+          <h1>Welcome back, {user?.displayName}</h1>
+          <p className="muted">
+            Role: <strong>{user?.role.name}</strong>
+          </p>
+        </div>
+        <button className="ghost" onClick={logout}>
+          Sign out
+        </button>
+      </header>
+
+      {feedback && (
+        <div className="notice" role="status">
+          {feedback}
+          <button className="ghost" onClick={() => setFeedback(null)}>
+            ×
+          </button>
+        </div>
+      )}
+
+      {errorMessage && <p className="error">{errorMessage}</p>}
+
+      {hasRole('TEACHER') && (
+        <section>
+          <ActivityForm
+            initial={editing}
+            goals={goals}
+            onSubmit={handleSubmit}
+            onCancel={() => setEditing(null)}
+            submitLabel={editing ? 'Save Changes' : 'Create Activity'}
+          />
+        </section>
+      )}
+
+      <section>
+        <div className="card">
+          <h2>Activity Log</h2>
+          {loading && <p>Loading activities…</p>}
+          {!loading && activityQuery.data && (
+            <ActivityTable
+              activities={activityQuery.data}
+              onEdit={(activity) => setEditing(activity)}
+              onDelete={(activity) => {
+                if (window.confirm('Delete this draft activity?')) {
+                  deleteMutation.mutate(activity.id);
+                }
+              }}
+              onSubmitDraft={handleSubmitDraft}
+              onTransition={handleApproval}
+              onAddComment={handleAddComment}
+              canApprove={hasRole('SUPERVISOR', 'ADMIN')}
+              userId={user!.id}
+            />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/components/LoginView.tsx
+++ b/src/components/LoginView.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+const LoginView: React.FC = () => {
+  const { login, error } = useAuth();
+  const [email, setEmail] = useState('teacher@example.com');
+  const [password, setPassword] = useState('password123');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
+    setMessage(null);
+    try {
+      await login(email, password);
+    } catch (err) {
+      setMessage('Unable to authenticate. Check your credentials.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-wrapper">
+      <form className="card" onSubmit={handleSubmit}>
+        <h1>KRUchat Activity Tracker</h1>
+        <p className="muted">Sign in with your local account to continue.</p>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
+        </label>
+        <button type="submit" disabled={loading}>
+          {loading ? 'Signing in…' : 'Sign in'}
+        </button>
+        {(error || message) && <p className="error">{message ?? error}</p>}
+        <p className="hint">Try teacher@example.com or supervisor@example.com with password123.</p>
+      </form>
+    </div>
+  );
+};
+
+export default LoginView;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,60 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+import { authenticate } from '../api';
+import { LoginResponse, RoleName, UserDto } from '../types';
+
+interface AuthContextValue {
+  user: UserDto | null;
+  token: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  hasRole: (...roles: RoleName[]) => boolean;
+  error: string | null;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [session, setSession] = useState<LoginResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const login = async (email: string, password: string) => {
+    try {
+      const response = await authenticate(email, password);
+      setSession(response);
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError('Invalid credentials.');
+      throw err;
+    }
+  };
+
+  const logout = () => setSession(null);
+
+  const hasRole = (...roles: RoleName[]) => {
+    if (!session?.user) return false;
+    return roles.includes(session.user.role.name);
+  };
+
+  const value = useMemo(
+    () => ({
+      user: session?.user ?? null,
+      token: session?.token ?? null,
+      login,
+      logout,
+      hasRole,
+      error,
+    }),
+    [session, error],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return ctx;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+import './styles.css';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,215 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1e293b, #0f172a 60%);
+}
+
+.layout {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(15, 23, 42, 0.6);
+  padding: 1.5rem 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.4);
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 20px 50px rgba(8, 14, 29, 0.55);
+}
+
+.auth-wrapper {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+input,
+select,
+textarea {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+}
+
+button {
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  color: #0f172a;
+  font-weight: 700;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 35px rgba(99, 102, 241, 0.4);
+}
+
+button.ghost {
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+button.primary {
+  background: linear-gradient(135deg, #34d399, #22d3ee);
+}
+
+.muted {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tags span {
+  background: rgba(59, 130, 246, 0.2);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.history ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.history li {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+}
+
+.history small {
+  display: block;
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.status {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.status-draft {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.status-submitted {
+  background: rgba(59, 130, 246, 0.25);
+}
+
+.status-approved {
+  background: rgba(34, 197, 94, 0.25);
+}
+
+.status-rejected {
+  background: rgba(239, 68, 68, 0.25);
+}
+
+.error {
+  color: #fca5a5;
+}
+
+.notice {
+  background: rgba(34, 211, 238, 0.15);
+  padding: 1rem 1.5rem;
+  border-radius: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.activity header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.activity .reflection {
+  font-style: italic;
+}
+
+.hint {
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.85rem;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,95 @@
+export type RoleName = 'TEACHER' | 'SUPERVISOR' | 'ADMIN';
+
+export interface RoleDto {
+  id: number;
+  name: RoleName;
+}
+
+export interface UserDto {
+  id: number;
+  email: string;
+  displayName: string;
+  role: RoleDto;
+}
+
+export type ActivityStatus = 'DRAFT' | 'SUBMITTED' | 'APPROVED' | 'REJECTED';
+
+export type ActivityType =
+  | 'SERVICE'
+  | 'PROFESSIONAL_DEVELOPMENT'
+  | 'COMMUNITY'
+  | 'OTHER';
+
+export interface ActivityStatusEntry {
+  id: number;
+  status: ActivityStatus;
+  comment?: string | null;
+  changedBy?: {
+    id: number;
+    displayName: string;
+    role: RoleName;
+  } | null;
+  createdAt: string;
+}
+
+export interface ActivityComment {
+  id: number;
+  body: string;
+  author: {
+    id: number;
+    displayName: string;
+    role: RoleName;
+  };
+  createdAt: string;
+}
+
+export interface ActivityDto {
+  id: number;
+  title: string;
+  activityType: ActivityType;
+  provider?: string | null;
+  activityDate: string;
+  hours: number;
+  reflection?: string | null;
+  status: ActivityStatus;
+  owner: UserDto;
+  reviewer?: UserDto | null;
+  tags: string[];
+  goalId?: number | null;
+  createdAt: string;
+  updatedAt: string;
+  statusHistory: ActivityStatusEntry[];
+  comments: ActivityComment[];
+}
+
+export interface ActivityInput {
+  title: string;
+  activityType: ActivityType;
+  provider?: string | null;
+  activityDate: string;
+  hours: number;
+  reflection?: string | null;
+  tags: string[];
+  goalId?: number | null;
+}
+
+export interface LoginResponse {
+  token: string;
+  user: UserDto;
+}
+
+export interface YearlyGoalDto {
+  id: number;
+  year: number;
+  targetHours: number;
+  notes?: string | null;
+}
+
+export interface ActivityFilters {
+  status?: ActivityStatus;
+  ownerId?: number;
+}
+
+export interface ValidationError {
+  message: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- replace the static site with a Vite/React dashboard that signs in against the local database and drives activity CRUD, RBAC, and workflow transitions
- add a Tauri backend with Prisma-managed SQLite schema, automatic seeding, and commands that expose authentication, activity CRUD, status history, goals, and comments
- define Prisma schema, migration, and seed data for roles, users, activities, goals, rubric configuration, and evidence metadata while placing the database in the Tauri app data directory

## Testing
- `pnpm install` *(fails: registry.npmjs.org returns HTTP 403 from the execution environment)*
- `pnpm --dir src-tauri install` *(fails: registry.npmjs.org returns HTTP 403 from the execution environment)*
- `cargo generate-lockfile` *(fails: crates.io index fetch blocked by HTTP 403 in the execution environment)*
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_68cbf2496214832298611a4b234b3ea0